### PR TITLE
Fix #43 - gam_config.target() returns only relevant target values, not all of them

### DIFF
--- a/line_item_manager/gam_config.py
+++ b/line_item_manager/gam_config.py
@@ -38,7 +38,7 @@ def target(key: str, names: Iterable[str], operator='IS', match_type: str='EXACT
             displayName=name,
             matchType=match_type,
         ))
-    tgt_values = TargetingValues(key_id=tgt_key['id']).fetch(create=True, recs=recs, validate=True)
+    tgt_values = TargetingValues(key_id=tgt_key['id'], name=list(names)).fetch(create=True, recs=recs, validate=True)
     return dict(
         key=tgt_key,
         operator=operator,

--- a/tests/client.py
+++ b/tests/client.py
@@ -216,7 +216,15 @@ BIDDER_VIDEO_BIDDER_KEY_MAP_SVC_IDS = dict(
 )
 
 def rec_from_statement(statement):
-    return {i_['key']:i_['value']['value'] for i_ in statement['values']}
+    rec = {}
+    for i_ in statement['values']:
+        key = i_['key']
+        if i_['value']['xsi_type'] == 'SetValue':
+            value = [v['value'] for v in i_['value']['values']]
+        else:
+            value = i_['value']['value']
+        rec[key] = value
+    return rec
 
 def svc_id(svc_recs, rec):
     _id = None


### PR DESCRIPTION
This is fix for #43. Now only relevant key-values are returned by gam_config.target function. It uses the standard filtering functionality of the CustomTargetingService API service.

I also have to fix test mocking, because rec_from_statement can't handle values with type SetValue  -> raised exception.