### PR TITLE
Release 0.2.5

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+0.2.5 (2022-02-08)
+-------------------
+* Update Google Ad Manager to v202105 (#93)
+* Remove Python 3.6 and add 3.10 support (#91)
+* Support for more line item types (sponsorship line item creation) (#86)
+* BUG FIX: Certain currency values are invalid (#73)
+
 0.2.4 (2021-12-01)
 -------------------
 * Update Google Ad Manager to v202102 (#63)

--- a/line_item_manager/__init__.py
+++ b/line_item_manager/__init__.py
@@ -2,10 +2,10 @@
 
 __author__ = """the prebid contributors"""
 __email__ = 'info@prebid.org'
-__version__ = '0.2.4'
+__version__ = '0.2.5'
 
 # For an official release, use dev_version = ''
-dev_version = '5'
+dev_version = ''
 
 version = __version__
 if dev_version:

--- a/line_item_manager/conf.d/line_item_manager.yml
+++ b/line_item_manager/conf.d/line_item_manager.yml
@@ -1,5 +1,5 @@
 # line_item_manager configuration
-# version: '0.2.4'
+# version: '0.2.5'
 ###############################################################################
 # Templating uses jinja2 rendering (see https://palletsprojects.com/p/jinja/)
 # The following key word types are supported:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.4
+current_version = 0.2.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,6 @@ setup(
     setup_requires=setup_requirements,
     test_suite='tests',
     url='https://github.com/prebid/line-item-manager',
-    version='0.2.4',
+    version='0.2.5',
     zip_safe=False,
 )


### PR DESCRIPTION
* Update Google Ad Manager to v202105 (#93)
* Remove Python 3.6 and add 3.10 support (#91)
* Support for more line item types (sponsorship line item creation) (#86)
* BUG FIX: Certain currency values are invalid (#73)
