### PR TITLE
Ability to configure included and excluded geotargeting locations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN pip3 install -e .[release,test]
 
 COPY line_item_manager/ ${APP_DIR}/line_item_manager
 COPY tests/ ${APP_DIR}/tests/
+COPY config/my_config.yml ${APP_DIR}/my_config.yml
+COPY config/gam_creds.json ${APP_DIR}/gam_creds.json
 COPY Makefile ${APP_DIR}/
 COPY *.rst ${APP_DIR}/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,6 @@ RUN pip3 install -e .[release,test]
 
 COPY line_item_manager/ ${APP_DIR}/line_item_manager
 COPY tests/ ${APP_DIR}/tests/
-COPY config/my_config.yml ${APP_DIR}/my_config.yml
-COPY config/gam_creds.json ${APP_DIR}/gam_creds.json
 COPY Makefile ${APP_DIR}/
 COPY *.rst ${APP_DIR}/
 

--- a/line_item_manager/conf.d/line_item_template.yml
+++ b/line_item_manager/conf.d/line_item_template.yml
@@ -49,6 +49,23 @@ targeting:
       {% for placement in li.gam.placements|sort(attribute='id') %}
       - {{ placement.id }}
       {% endfor %}
+  {% if li.gam.geographies %}
+  geoTargeting:
+    {% if li.gam.geographies.include|length != 0 %}
+    includedLocations:
+      {% for geo in li.gam.geographies.include %}
+      - xsi_type: "Location"
+        id: {{ geo.id }}
+      {% endfor %}
+    {% endif %}
+    {% if li.gam.geographies.exclude|length != 0 %}
+    excludedLocations:
+      {% for geo in li.gam.geographies.exclude %}
+      - xsi_type: "Location"
+        id: {{ geo.id }}
+      {% endfor %}
+    {% endif %}
+  {% endif %}
   customTargeting:
     xsi_type: "CustomCriteriaSet"
     logicalOperator: "AND"

--- a/line_item_manager/conf.d/schema.yml
+++ b/line_item_manager/conf.d/schema.yml
@@ -131,6 +131,20 @@ properties:
     then:
       required:
         - "end_datetime"
+  geographies:
+    type: "object"
+    additionalProperties: False
+    properties:
+      include:
+        type: "array"
+        minItems: 0
+        items:
+          type: "string"
+      exclude:
+        type: "array"
+        minItems: 0
+        items:
+          type: "string"
   targeting:
     type: "object"
     additionalProperties: False

--- a/line_item_manager/config.py
+++ b/line_item_manager/config.py
@@ -113,6 +113,12 @@ class Config:
             for _c in self.user.get('targeting', {}).get('custom', [])
         ]
 
+    def geographies(self) -> Dict[str,List[str]]:
+        return dict(
+            include=[_c for _c in self.user.get('geographies', {}).get('include', [])],
+            exclude=[_c for _c in self.user.get('geographies', {}).get('exclude', [])]
+        )
+
     def cpm_buckets(self) -> List[Dict[str, float]]:
         _type = self.user['rate']['granularity']['type']
         if _type == "custom":


### PR DESCRIPTION
We needed the ability to configure geo targeting when generating our line items, and I noticed there is no way to do that currently, so I gave it a shot. Hopefully this will help, it's probably not a perfect solution.

Example config:
```
geographies:
  include:
    - United States
  exclude:
    - Florida
 ```

I had to mess with the `AppOperations` logic a bit, since there doesn't seem to be an API for getting geos by name. It may be a good idea to separate this more query-based logic to a base class if there are other gaps in the API that need to be filled this way.