### PR TITLE
Add support for duplicating copies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+qz/
+.gitpod.yml
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/line_item_manager/conf.d/schema.yml
+++ b/line_item_manager/conf.d/schema.yml
@@ -40,6 +40,8 @@ properties:
         type: "object"
         additionalProperties: False
         properties:
+          copies:
+            $ref: "#/definitions/positiveIntegerType"
           sizes:
             $ref: "#/definitions/sizeArray"
           snippet:

--- a/line_item_manager/gam_config.py
+++ b/line_item_manager/gam_config.py
@@ -112,12 +112,13 @@ class GAMLineItems:
         return self.create_licas_batched(recs)
 
     @property
-    def creatives(self, copies=5) -> List[dict]:
+    def creatives(self) -> List[dict]:
         if self._creatives is None:
             cfg = render_cfg('creative', self.bidder, media_type=self.media_type)
             _name = f'creative_{self.media_type}'
             _method = getattr(self, _name)
             log(_name, obj={k:cfg[k] for k in ('name', self.media_type)})
+            copies = cfg[self.media_type].get('copies', 1) if (self.media_type == 'banner') else 1
             self._creatives = [_method(i_, cfg, size) \
                                for i_, size in enumerate(cfg[self.media_type]['sizes'] * copies)]
         return self._creatives

--- a/line_item_manager/gam_config.py
+++ b/line_item_manager/gam_config.py
@@ -1,3 +1,5 @@
+import uuid
+
 from datetime import datetime
 from pprint import pformat
 from typing import Any, List, Iterable, Optional
@@ -110,14 +112,14 @@ class GAMLineItems:
         return self.create_licas_batched(recs)
 
     @property
-    def creatives(self) -> List[dict]:
+    def creatives(self, copies=5) -> List[dict]:
         if self._creatives is None:
             cfg = render_cfg('creative', self.bidder, media_type=self.media_type)
             _name = f'creative_{self.media_type}'
             _method = getattr(self, _name)
             log(_name, obj={k:cfg[k] for k in ('name', self.media_type)})
             self._creatives = [_method(i_, cfg, size) \
-                               for i_, size in enumerate(cfg[self.media_type]['sizes'])]
+                               for i_, size in enumerate(cfg[self.media_type]['sizes'] * copies)]
         return self._creatives
 
     def creative_name(self, cfg: dict, index: int):
@@ -128,7 +130,7 @@ class GAMLineItems:
 
     def creative_banner(self, index: int, cfg: dict, size: dict) -> dict:
         params = dict(
-            name=self.creative_name(cfg, index),
+            name=f"{self.creative_name(cfg, index)}-{size['width']}x{size['height']}-{str(uuid.uuid4())[:8]}",
             advertiserId=self.advertiser['id'],
             size=config.app['prebid']['creative']['size_override'] if self.is_size_override else size,
             snippet=cfg['banner']['snippet'],


### PR DESCRIPTION
- Added `copies` to schema of banner object
  - if set to > 1, creative will be duplicated 
- Added hash to creative name so that duplicates can be made
- Added size to creative name because I feel that should be in there